### PR TITLE
Breaking: Fix CJS interop

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "postcss-assign-layer"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts",
+    "build": "tsup src/index.ts --format esm,cjs --dts --cjsInterop --splitting",
     "test": "vitest run --coverage && eslint .",
     "test:watch": "vitest",
     "prepublishOnly": "pnpm build && pnpm test"

--- a/src/index.test.mts
+++ b/src/index.test.mts
@@ -3,7 +3,8 @@ import path from "node:path";
 import postcss from "postcss";
 import prettier from "prettier";
 import { describe, it, expect } from "vitest";
-import { plugin, type PluginOptions } from "./index";
+import type { PluginOptions } from "./index";
+import plugin from "./index";
 
 // We don't care about formatting differences, so normalize with prettier
 function format(css: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ type ConfigItem = {
 };
 export type PluginOptions = ConfigItem[];
 
-export const plugin: PluginCreator<PluginOptions> = (
+const plugin: PluginCreator<PluginOptions> = (
   configItems = [
     {
       include: DEFAULT_INCLUDE,


### PR DESCRIPTION
Avoids adding a `.default` property on the cjs exports.

Fixes #8 

Note: the `--splitting` flag is a hack to work around an esbuild bug: https://github.com/egoist/tsup/issues/572#issuecomment-1927105408